### PR TITLE
openapi-route-patch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 StackQL Studios
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+<!-- language: lang-none -->
+
+![Platforms](https://img.shields.io/badge/platform-windows%20macos%20linux-brightgreen)
+![Go](https://github.com/stackql/stackql/workflows/Go/badge.svg)
+![License](https://img.shields.io/github/license/stackql/stackql)
+![Lines](https://img.shields.io/tokei/lines/github/stackql/stackql)  
+[![StackQL](https://stackql.io/img/stackql-banner.png)](https://stackql.io/)  
+
+
+# openapistackql
+
+A golang library to support:
+  - traversal algorithms on StackQL augmented openapi doc structure.
+  - SQL semantics thereupon.
+
+## Acknowledgements
+
+Extensions, adaptations and shims of the following support our work:
+
+  - [kin-openapi](https://github.com/getkin/kin-openapi)
+  - [gorilla/mux](https://vitess.io/)
+
+We gratefully acknowledge these pieces of work.
+
+## Licensing
+
+Please see the [stackql LICENSE](/LICENSE).
+
+Licenses for third party software we are using are included in the [/licenses](/licenses) directory.

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,12 @@
+
+## Summary
+
+This directory contains licenses from products leveraged / forked / adapted to support go-openapistackql.
+
+Some deep links to original licenses are supplied for convenience:
+
+
+| Name  | Source | Local copy if present | Original License |
+| ----- | ----- | ------ | ------ |
+| kin-openapi | https://github.com/getkin/kin-openapi | [kin-openapi_license](/licenses/kin-openapi_license) | https://github.com/getkin/kin-openapi/blob/c95dd68aef43fa9ac8c1f52f169b387d7681626a/LICENSE |
+| gorila/mux | https://github.com/gorilla/mux | [gorillamux_license](/licenses/gorillamux_license) | https://github.com/gorilla/mux/blob/master/LICENSE |

--- a/licenses/gorillamux_license
+++ b/licenses/gorillamux_license
@@ -1,0 +1,27 @@
+Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+	 * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+	 * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+	 * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/kin-openapi_license
+++ b/licenses/kin-openapi_license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2018 the project authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/queryrouter/queryrouter.go
+++ b/pkg/queryrouter/queryrouter.go
@@ -1,13 +1,219 @@
 package queryrouter
 
+/*
+ * Abstraction layer for variations / extensions on
+ * gorillamux routers as leveraged by "github.com/getkin/kin-openapi/openapi3":
+ *   - Shim for routing with server variables.
+ *   - Open for extension as per open/closed principle.
+ *
+ * This is highly derivative of "github.com/getkin/kin-openapi/openapi3",
+ * and in particular https://github.com/getkin/kin-openapi/blob/c95dd68aef43fa9ac8c1f52f169b387d7681626a/routers/gorillamux/router.go
+ *
+ * "github.com/getkin/kin-openapi/openapi3" is
+ * fully acknowledged (and greatly appreciated) in our licensing pages and README.
+ */
+
 import (
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/routers"
-	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"github.com/gorilla/mux"
 )
 
-// An abstraction layer to provide a shim for functionality disallowed
-// by the gorillamux router; eg. IPv4 addresses as server variabless
+var _ routers.Router = &Router{}
+
+type Router struct {
+	muxes  []*mux.Route
+	routes []*routers.Route
+}
+
 func NewRouter(doc *openapi3.T) (routers.Router, error) {
-	return gorillamux.NewRouter(doc)
+	type srv struct {
+		schemes    []string
+		host, base string
+		server     *openapi3.Server
+	}
+	servers := make([]srv, 0, len(doc.Servers))
+	for _, server := range doc.Servers {
+		serverURL := server.URL
+		var schemes []string
+		var u *url.URL
+		var err error
+		if strings.Contains(serverURL, "://") {
+			scheme0 := strings.Split(serverURL, "://")[0]
+			schemes = permutePart(scheme0, server)
+			u, err = url.Parse(bEncode(strings.Replace(serverURL, scheme0+"://", schemes[0]+"://", 1)))
+		} else {
+			u, err = url.Parse(bEncode(serverURL))
+		}
+		if err != nil {
+			return nil, err
+		}
+		path := bDecode(u.EscapedPath())
+		if len(path) > 0 && path[len(path)-1] == '/' {
+			path = path[:len(path)-1]
+		}
+		servers = append(servers, srv{
+			host:    bDecode(u.Host), //u.Hostname()?
+			base:    path,
+			schemes: schemes, // scheme: []string{scheme0}, TODO: https://github.com/gorilla/mux/issues/624
+			server:  server,
+		})
+	}
+	if len(servers) == 0 {
+		servers = append(servers, srv{})
+	}
+	muxRouter := mux.NewRouter().UseEncodedPath()
+	r := &Router{}
+	for _, path := range orderedPaths(doc.Paths) {
+		pathItem := doc.Paths[path]
+
+		operations := pathItem.Operations()
+		methods := make([]string, 0, len(operations))
+		for method := range operations {
+			methods = append(methods, method)
+		}
+		sort.Strings(methods)
+
+		for _, s := range servers {
+			muxRoute := muxRouter.Path(s.base + path).Methods(methods...)
+			if strings.HasPrefix(path, "/?") {
+				var pairs []string
+				kvs := strings.Split(path[2:], "&")
+				for _, v := range kvs {
+					pairs = append(pairs, strings.Split(v, "=")...)
+				}
+				muxRoute = muxRouter.Queries(pairs...).Methods(methods...)
+			}
+			if schemes := s.schemes; len(schemes) != 0 {
+				muxRoute.Schemes(schemes...)
+			}
+			if host := s.host; host != "" {
+				muxRoute.Host(host)
+			}
+			if err := muxRoute.GetError(); err != nil {
+				return nil, err
+			}
+			r.muxes = append(r.muxes, muxRoute)
+			r.routes = append(r.routes, &routers.Route{
+				Spec:      doc,
+				Server:    s.server,
+				Path:      path,
+				PathItem:  pathItem,
+				Method:    "",
+				Operation: nil,
+			})
+		}
+	}
+	return r, nil
+}
+
+func (r *Router) FindRoute(req *http.Request) (*routers.Route, map[string]string, error) {
+	for i, muxRoute := range r.muxes {
+		var match mux.RouteMatch
+		if muxRoute.Match(req, &match) {
+			if err := match.MatchErr; err != nil {
+				// What then?
+			}
+			route := *r.routes[i]
+			route.Method = req.Method
+			route.Operation = route.Spec.Paths[route.Path].GetOperation(route.Method)
+			return &route, match.Vars, nil
+		}
+		switch match.MatchErr {
+		case nil:
+		case mux.ErrMethodMismatch:
+			return nil, nil, routers.ErrMethodNotAllowed
+		default: // What then?
+		}
+	}
+	return nil, nil, routers.ErrPathNotFound
+}
+
+func orderedPaths(paths map[string]*openapi3.PathItem) []string {
+	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#pathsObject
+	// When matching URLs, concrete (non-templated) paths would be matched
+	// before their templated counterparts.
+	// NOTE: sorting by number of variables ASC then by descending lexicographical
+	// order seems to be a good heuristic.
+	vars := make(map[int][]string)
+	max := 0
+	for path := range paths {
+		count := strings.Count(path, "}")
+		vars[count] = append(vars[count], path)
+		if count > max {
+			max = count
+		}
+	}
+	ordered := make([]string, 0, len(paths))
+	for c := 0; c <= max; c++ {
+		if ps, ok := vars[c]; ok {
+			sort.Sort(sort.Reverse(sort.StringSlice(ps)))
+			ordered = append(ordered, ps...)
+		}
+	}
+	return ordered
+}
+
+// Magic strings that temporarily replace "{}" so net/url.Parse() works
+var blURL, brURL = strings.Repeat("-", 50), strings.Repeat("_", 50)
+
+func bEncode(s string) string {
+	s = strings.Replace(s, "{", blURL, -1)
+	s = strings.Replace(s, "}", brURL, -1)
+	return s
+}
+func bDecode(s string) string {
+	s = strings.Replace(s, blURL, "{", -1)
+	s = strings.Replace(s, brURL, "}", -1)
+	return s
+}
+
+func permutePart(part0 string, srv *openapi3.Server) []string {
+	type mapAndSlice struct {
+		m map[string]struct{}
+		s []string
+	}
+	var2val := make(map[string]mapAndSlice)
+	max := 0
+	for name0, v := range srv.Variables {
+		name := "{" + name0 + "}"
+		if !strings.Contains(part0, name) {
+			continue
+		}
+		m := map[string]struct{}{v.Default: {}}
+		for _, value := range v.Enum {
+			m[value] = struct{}{}
+		}
+		if l := len(m); l > max {
+			max = l
+		}
+		s := make([]string, 0, len(m))
+		for value := range m {
+			s = append(s, value)
+		}
+		var2val[name] = mapAndSlice{m: m, s: s}
+	}
+	if len(var2val) == 0 {
+		return []string{part0}
+	}
+
+	partsMap := make(map[string]struct{}, max*len(var2val))
+	for i := 0; i < max; i++ {
+		part := part0
+		for name, mas := range var2val {
+			part = strings.Replace(part, name, mas.s[i%len(mas.s)], -1)
+		}
+		partsMap[part] = struct{}{}
+	}
+	parts := make([]string, 0, len(partsMap))
+	for part := range partsMap {
+		parts = append(parts, part)
+	}
+	sort.Strings(parts)
+	return parts
 }


### PR DESCRIPTION
## Summary

- Shim on top of openapi doc module and gorrila/mux routing, to support required server variables.
- License enrichment.
- README enrichment.