### PR TITLE
support-method-verb-display

### DIFF
--- a/openapistackql/const.go
+++ b/openapistackql/const.go
@@ -4,6 +4,7 @@ const (
 	MethodDescription string = "description"
 	MethodName        string = "MethodName"
 	RequiredParams    string = "RequiredParams"
+	SQLVerb           string = "SQLVerb"
 )
 
 const (

--- a/openapistackql/loader.go
+++ b/openapistackql/loader.go
@@ -180,7 +180,7 @@ func (l *Loader) mergeResource(svc *Service, rsc *Resource, sr *ServiceRef) erro
 	for sqlVerb, dir := range rsc.SQLVerbs {
 		for i, v := range dir {
 			cur := v
-			err := l.resolveSQLVerb(rsc, &cur)
+			err := l.resolveSQLVerb(rsc, &cur, sqlVerb)
 			if err != nil {
 				return err
 			}
@@ -531,7 +531,7 @@ func (loader *Loader) resolveExpectedRequest(doc *Service, op *openapi3.Operatio
 	return nil
 }
 
-func (loader *Loader) resolveSQLVerb(rsc *Resource, component *OperationStoreRef) (err error) {
+func (loader *Loader) resolveSQLVerb(rsc *Resource, component *OperationStoreRef, sqlVerb string) (err error) {
 	if component != nil && component.Value != nil {
 		if loader.visitedOperationStore == nil {
 			loader.visitedOperationStore = make(map[*OperationStore]struct{})
@@ -542,22 +542,36 @@ func (loader *Loader) resolveSQLVerb(rsc *Resource, component *OperationStoreRef
 		loader.visitedOperationStore[component.Value] = struct{}{}
 	}
 
-	if component == nil {
-		return fmt.Errorf("operation store ref not supplied")
-	}
-	osv, _, err := jsonpointer.GetForToken(rsc, component.Ref)
+	resolved, err := resolveSQLVerbFromResource(rsc, component, sqlVerb)
 	if err != nil {
 		return err
 	}
-	resolved, ok := osv.(*OperationStore)
-	if !ok {
-		return fmt.Errorf("operation store ref type '%T' not supported", osv)
-	}
+	resolved.SQLVerb = sqlVerb
 	component.Value = resolved
 	if component.Value == nil {
 		return fmt.Errorf("operation store ref not resolved")
 	}
 	return nil
+}
+
+func resolveSQLVerbFromResource(rsc *Resource, component *OperationStoreRef, sqlVerb string) (*OperationStore, error) {
+
+	if component == nil {
+		return nil, fmt.Errorf("operation store ref not supplied")
+	}
+	osv, _, err := jsonpointer.GetForToken(rsc, component.Ref)
+	if err != nil {
+		return nil, err
+	}
+	resolved, ok := osv.(*OperationStore)
+	if !ok {
+		return nil, fmt.Errorf("operation store ref type '%T' not supported", osv)
+	}
+	if resolved == nil {
+		return nil, fmt.Errorf("operation store ref not resolved")
+	}
+	resolved.SQLVerb = sqlVerb
+	return resolved, nil
 }
 
 func (loader *Loader) resolveExpectedResponse(doc *Service, op *openapi3.Operation, component *ExpectedResponse) (err error) {

--- a/openapistackql/operation_store.go
+++ b/openapistackql/operation_store.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
-	"github.com/stackql/go-openapistackql/pkg/openapitoxpath"
 	"github.com/stackql/go-openapistackql/pkg/queryrouter"
 
 	log "github.com/sirupsen/logrus"
@@ -32,6 +31,52 @@ func (ms Methods) FindMethod(key string) (*OperationStore, error) {
 		return &m, nil
 	}
 	return nil, fmt.Errorf("could not find method for key = '%s'", key)
+}
+
+func sortOperationStoreSlices(opSlices ...[]OperationStore) {
+	for _, opSlice := range opSlices {
+		sort.SliceStable(opSlice, func(i, j int) bool {
+			return opSlice[i].MethodKey < opSlice[j].MethodKey
+		})
+	}
+}
+
+func combineOperationStoreSlices(opSlices ...[]OperationStore) []OperationStore {
+	var rv []OperationStore
+	for _, sl := range opSlices {
+		rv = append(rv, sl...)
+	}
+	return rv
+}
+
+func (ms Methods) OrderMethods() ([]OperationStore, error) {
+	var selectBin, insertBin, deleteBin, updateBin, execBin []OperationStore
+	for k, v := range ms {
+		switch v.SQLVerb {
+		case "select":
+			v.MethodKey = k
+			selectBin = append(selectBin, v)
+		case "insert":
+			v.MethodKey = k
+			insertBin = append(insertBin, v)
+		case "update":
+			v.MethodKey = k
+			updateBin = append(updateBin, v)
+		case "delete":
+			v.MethodKey = k
+			deleteBin = append(deleteBin, v)
+		case "exec":
+			v.MethodKey = k
+			execBin = append(execBin, v)
+		default:
+			v.MethodKey = k
+			v.SQLVerb = "exec"
+			execBin = append(execBin, v)
+		}
+	}
+	sortOperationStoreSlices(selectBin, insertBin, deleteBin, updateBin, execBin)
+	rv := combineOperationStoreSlices(selectBin, insertBin, deleteBin, updateBin, execBin)
+	return rv, nil
 }
 
 func (ms Methods) FindFromSelector(sel OperationSelector) (*OperationStore, error) {
@@ -71,7 +116,7 @@ type ExpectedResponse struct {
 
 type OperationStore struct {
 	MethodKey string `json:"-" yaml:"-"`
-	SQLVerb   string `json:"sqlVerb" yaml:"sqlVerb"` // Required
+	SQLVerb   string `json:"-" yaml:"-"` // Required
 	// Optional parameters.
 	Parameters   map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	PathItem     *openapi3.PathItem     `json:"-" yaml:"-"`                 // Required
@@ -195,13 +240,6 @@ func (m *OperationStore) getSelectItemsKeySimple() string {
 	return ""
 }
 
-func (m *OperationStore) getSelectItemsPath() []string {
-	if m.Response != nil {
-		return openapitoxpath.ToPathSlice(m.Response.ObjectKey)
-	}
-	return openapitoxpath.ToPathSlice(defaultSelectItemsKey)
-}
-
 func (m *OperationStore) GetKey(lhs string) (interface{}, error) {
 	val, ok := m.ToPresentationMap(true)[lhs]
 	if !ok {
@@ -214,6 +252,7 @@ func (m *OperationStore) GetColumnOrder(extended bool) []string {
 	retVal := []string{
 		MethodName,
 		RequiredParams,
+		SQLVerb,
 	}
 	if extended {
 		retVal = append(retVal, MethodDescription)
@@ -344,12 +383,17 @@ func (m *OperationStore) ToPresentationMap(extended bool) map[string]interface{}
 	}
 	sort.Strings(requiredParamNames)
 	sort.Strings(requiredBodyParamNames)
-	for _, s := range requiredBodyParamNames {
-		requiredParamNames = append(requiredParamNames, s)
+	requiredParamNames = append(requiredParamNames, requiredBodyParamNames...)
+
+	sqlVerb := m.SQLVerb
+	if sqlVerb == "" {
+		sqlVerb = "EXEC"
 	}
+
 	retVal := map[string]interface{}{
 		MethodName:     m.MethodKey,
 		RequiredParams: strings.Join(requiredParamNames, ", "),
+		SQLVerb:        strings.ToUpper(sqlVerb),
 	}
 	if extended {
 		retVal[MethodDescription] = m.OperationRef.Value.Description

--- a/openapistackql/refs.go
+++ b/openapistackql/refs.go
@@ -35,9 +35,7 @@ func (opr OperationRef) ExtractMethodItem() string {
 }
 
 func (opr OperationRef) extractMethodItem() string {
-	s := opr.extractFragment()
-	elems := strings.Split(s, "/")
-	return elems[len(elems)-1]
+	return extractSuffix(opr.Ref)
 }
 
 func (opr OperationRef) ExtractServiceDocPath() string {
@@ -53,8 +51,7 @@ func (opr OperationRef) extractServiceDocPath() string {
 	return s
 }
 
-func (opr OperationRef) extractFragment() string {
-	s := opr.Ref
+func extractFragment(s string) string {
 	if strings.HasPrefix(s, "#") {
 		return s[1:]
 	}
@@ -65,9 +62,23 @@ func (opr OperationRef) extractFragment() string {
 	return elems[len(elems)-1]
 }
 
+func extractSuffix(s string) string {
+	sf := extractFragment(s)
+	elems := strings.Split(sf, "/")
+	return elems[len(elems)-1]
+}
+
+func (opr OperationRef) extractFragment() string {
+	return extractFragment(opr.Ref)
+}
+
 type OperationStoreRef struct {
 	Ref   string `json:"$ref" yaml:"$ref"`
 	Value *OperationStore
+}
+
+func (osr OperationStoreRef) extractMethodItem() string {
+	return extractSuffix(osr.Ref)
 }
 
 type PathItemRef struct {


### PR DESCRIPTION
## Summary

- support `SQLVerb` assignment to methods without parsing entire `openapi` doc.
- corollary; support for `SHOW METHODS` containing `SQLVerb`.