### PR TITLE
nil-xpath-to-return-nil-result-and-not-error

### DIFF
--- a/pkg/xmlmap/xmlmap.go
+++ b/pkg/xmlmap/xmlmap.go
@@ -235,6 +235,9 @@ func GetSubObjTyped(xmlReader io.ReadCloser, path string, schema *openapi3.Schem
 			}
 			return []map[string]interface{}{mc}, doc, nil
 		case []map[string]string:
+			if len(raw) == 0 {
+				return nil, doc, nil
+			}
 			if len(raw) != 1 {
 				return nil, nil, fmt.Errorf("cannot ")
 			}


### PR DESCRIPTION
## Summary:

- Prior: xpath pointing to nil returns error.
- Post: xpath pointing to nil returns nil.
- In this way, support is added for empty result sets for xml apis.