### PR TITLE
support-weird-query-urls

### DIFF
--- a/openapistackql/operation_store.go
+++ b/openapistackql/operation_store.go
@@ -464,7 +464,7 @@ func (m *OperationStore) getRequiredNonBodyParameters() map[string]Addressable {
 	}
 	for _, p := range m.OperationRef.Value.Parameters {
 		param := p.Value
-		if param != nil && param.Required {
+		if param != nil && isOpenapi3ParamRequired(param) {
 			retVal[param.Name] = NewParameter(p.Value, m.Service)
 		}
 	}
@@ -495,6 +495,7 @@ func (m *OperationStore) getOptionalParameters() map[string]Addressable {
 	}
 	for _, p := range m.OperationRef.Value.Parameters {
 		param := p.Value
+		// TODO: handle the `?param` where value is not only not required but should NEVER be sent
 		if param != nil && !param.Required {
 			retVal[param.Name] = NewParameter(p.Value, m.Service)
 		}
@@ -699,7 +700,7 @@ func (op *OperationStore) Parameterize(prov *Provider, parentDoc *Service, input
 				delete(copyParams, name)
 			} else if p.Value != nil && p.Value.Schema != nil && p.Value.Schema.Value != nil && p.Value.Schema.Value.Default != nil {
 				prefilledHeader.Set(name, fmt.Sprintf("%v", p.Value.Schema.Value.Default))
-			} else if p.Value.Required {
+			} else if isOpenapi3ParamRequired(p.Value) {
 				return nil, fmt.Errorf("OperationStore.Parameterize() failure; missing required header '%s'", name)
 			}
 		}
@@ -709,7 +710,7 @@ func (op *OperationStore) Parameterize(prov *Provider, parentDoc *Service, input
 				pathParams[name] = fmt.Sprintf("%v", val.Val)
 				delete(copyParams, name)
 			}
-			if !present && p.Value.Required {
+			if !present && isOpenapi3ParamRequired(p.Value) {
 				return nil, fmt.Errorf("OperationStore.Parameterize() failure; missing required path parameter '%s'", name)
 			}
 		} else if p.Value.In == openapi3.ParameterInQuery {
@@ -855,11 +856,11 @@ func (op *OperationStore) GetSelectSchemaAndObjectPath() (*Schema, string, error
 }
 
 func (op *OperationStore) ProcessResponse(response *http.Response) (*response.Response, error) {
-	responseSchema, _, err := op.GetResponseBodySchemaAndMediaType()
+	responseSchema, mediaType, err := op.GetResponseBodySchemaAndMediaType()
 	if err != nil {
 		return nil, err
 	}
-	return responseSchema.ProcessHttpResponse(response, op.lookupSelectItemsKey())
+	return responseSchema.processHttpResponse(response, op.lookupSelectItemsKey(), mediaType)
 }
 
 func (ops *OperationStore) lookupSelectItemsKey() string {

--- a/openapistackql/operation_store_test.go
+++ b/openapistackql/operation_store_test.go
@@ -34,7 +34,7 @@ func TestPlaceholder(t *testing.T) {
 		Body:       ioutil.NopCloser(strings.NewReader(`{"a": { "b": [ "c" ] } }`)),
 	}
 	s := NewSchema(openapi3.NewSchema(), nil, "")
-	pr, err := s.ProcessHttpResponse(res, "")
+	pr, err := s.ProcessHttpResponseTesting(res, "", "")
 	assert.NilError(t, err)
 	assert.Assert(t, pr != nil)
 }

--- a/openapistackql/params.go
+++ b/openapistackql/params.go
@@ -47,7 +47,11 @@ func (p *Parameter) GetSchema() (*Schema, bool) {
 }
 
 func (p *Parameter) IsRequired() bool {
-	return p.Required
+	return isOpenapi3ParamRequired(&p.Parameter)
+}
+
+func isOpenapi3ParamRequired(param *openapi3.Parameter) bool {
+	return param.Required && !param.AllowEmptyValue
 }
 
 func (p *Parameter) ConditionIsValid(lhs string, rhs interface{}) bool {

--- a/openapistackql/schema.go
+++ b/openapistackql/schema.go
@@ -971,7 +971,7 @@ func (s *Schema) unmarshalResponse(r *http.Response) (interface{}, error) {
 		return nil, nil
 	}
 	var target interface{}
-	mediaType, err := media.GetResponseMediaType(r)
+	mediaType, err := media.GetResponseMediaType(r, "")
 	if err != nil {
 		return nil, err
 	}
@@ -994,9 +994,9 @@ func (s *Schema) unmarshalResponse(r *http.Response) (interface{}, error) {
 	return target, err
 }
 
-func (s *Schema) unmarshalResponseAtPath(r *http.Response, path string) (*response.Response, error) {
+func (s *Schema) unmarshalResponseAtPath(r *http.Response, path string, defaultMediaType string) (*response.Response, error) {
 
-	mediaType, err := media.GetResponseMediaType(r)
+	mediaType, err := media.GetResponseMediaType(r, defaultMediaType)
 	if err != nil {
 		return nil, err
 	}
@@ -1038,9 +1038,13 @@ func (s *Schema) unmarshalResponseAtPath(r *http.Response, path string) (*respon
 	}
 }
 
-func (s *Schema) ProcessHttpResponse(r *http.Response, path string) (*response.Response, error) {
+func (s *Schema) ProcessHttpResponseTesting(r *http.Response, path string, defaultMediaType string) (*response.Response, error) {
+	return s.processHttpResponse(r, path, defaultMediaType)
+}
+
+func (s *Schema) processHttpResponse(r *http.Response, path string, defaultMediaType string) (*response.Response, error) {
 	defer r.Body.Close()
-	target, err := s.unmarshalResponseAtPath(r, path)
+	target, err := s.unmarshalResponseAtPath(r, path, defaultMediaType)
 	if err == nil && r.StatusCode >= 400 {
 		err = fmt.Errorf(fmt.Sprintf("HTTP response error.  Status code %d.  Detail: %s", r.StatusCode, string(util.InterfaceToBytes(target, true))))
 	}
@@ -1062,7 +1066,7 @@ func (s *Schema) ProcessHttpResponse(r *http.Response, path string) (*response.R
 }
 
 func (s *Schema) DeprecatedProcessHttpResponse(response *http.Response, path string) (map[string]interface{}, error) {
-	target, err := s.ProcessHttpResponse(response, path)
+	target, err := s.processHttpResponse(response, path, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -62,7 +62,7 @@ func isAcceptableMediaType(mediaType string) bool {
 	}
 }
 
-func GetResponseMediaType(r *http.Response) (string, error) {
+func GetResponseMediaType(r *http.Response, defaultMediaType string) (string, error) {
 	rt := r.Header.Get("Content-Type")
 	var mediaType string
 	var err error
@@ -73,5 +73,5 @@ func GetResponseMediaType(r *http.Response) (string, error) {
 		}
 		return mediaType, nil
 	}
-	return "", nil
+	return defaultMediaType, nil
 }

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -90,7 +90,7 @@ func (r *Response) ExtractElement(e httpelement.HTTPElement) (interface{}, error
 }
 
 func NewResponse(processedBody, rawBody interface{}, r *http.Response) *Response {
-	mt, _ := media.GetResponseMediaType(r)
+	mt, _ := media.GetResponseMediaType(r, "")
 	return &Response{
 		processedBody: processedBody,
 		rawBody:       rawBody,

--- a/pkg/xmlmap/xmlmap.go
+++ b/pkg/xmlmap/xmlmap.go
@@ -35,6 +35,12 @@ func getNodeKeyVal(node *xmlquery.Node) (kv, error) {
 		if ts == "" {
 			return kv{isNull: true}, nil
 		}
+		if node.Parent != nil {
+			return kv{
+				k: node.Parent.Data,
+				v: node.Data,
+			}, nil
+		}
 		return kv{}, fmt.Errorf("cannot get kv for node")
 	default:
 		return kv{


### PR DESCRIPTION
## Summary:

- Support strange URLs with query parameter exclusive of value, eg aws bucket poicy `...?policy`.
- Support top level xml element selections.