### PR TITLE
tabulation-back-ref-to-schema

### DIFF
--- a/openapistackql/schema.go
+++ b/openapistackql/schema.go
@@ -828,19 +828,18 @@ func (s *Schema) Tabulate(omitColumns bool) *Tabulation {
 				cols = s.getOneOfColumns()
 			}
 		}
-		return &Tabulation{columns: cols, name: s.GetName()}
+		return &Tabulation{columns: cols, name: s.GetName(), schema: s}
 	} else if s.Type == "array" {
 		if items := s.Items.Value; items != nil {
-
 			rv := newSchema(items, s.svc, "").Tabulate(omitColumns)
 			return rv
 		}
 	} else if s.Type == "string" {
 		cd := ColumnDescriptor{Name: AnonymousColumnName, Schema: s}
 		if omitColumns {
-			return &Tabulation{columns: []ColumnDescriptor{}, name: s.Title}
+			return &Tabulation{columns: []ColumnDescriptor{}, name: s.Title, schema: s}
 		}
-		return &Tabulation{columns: []ColumnDescriptor{cd}, name: s.Title}
+		return &Tabulation{columns: []ColumnDescriptor{cd}, name: s.Title, schema: s}
 	}
 	return nil
 }

--- a/openapistackql/table.go
+++ b/openapistackql/table.go
@@ -37,6 +37,7 @@ type Tabulation struct {
 	columns   []ColumnDescriptor
 	name      string
 	arrayType string
+	schema    *Schema
 }
 
 func GetTabulation(name, arrayType string) Tabulation {
@@ -45,6 +46,10 @@ func GetTabulation(name, arrayType string) Tabulation {
 
 func (t *Tabulation) GetColumns() []ColumnDescriptor {
 	return t.columns
+}
+
+func (t *Tabulation) GetSchema() *Schema {
+	return t.schema
 }
 
 func (t *Tabulation) PushBackColumn(col ColumnDescriptor) {


### PR DESCRIPTION
## Summary:

- The `Tabulation` object now supports a back reference to the richer `Schema` from which it is derived.