### PR TITLE
resource-level-view-nomenclature

### DIFF
--- a/openapistackql/const.go
+++ b/openapistackql/const.go
@@ -20,3 +20,7 @@ const (
 	RequestBodyKeyDelimiter string = "__"
 	RequestBodyBaseKey      string = RequestBodyKeyPrefix + RequestBodyKeyDelimiter
 )
+
+const (
+	ViewKeyResourceLevelSelect string = "select"
+)

--- a/openapistackql/resource.go
+++ b/openapistackql/resource.go
@@ -74,7 +74,7 @@ func (r *Resource) GetPaginationRequestTokenSemantic() (*TokenSemantic, bool) {
 
 func (r *Resource) GetViewBodyDDLForSQLDialect(sqlDialect string) (string, bool) {
 	if r.StackQLConfig != nil {
-		return r.StackQLConfig.GetViewBodyDDLForSQLDialect(sqlDialect, "")
+		return r.StackQLConfig.GetViewBodyDDLForSQLDialect(sqlDialect, ViewKeyResourceLevelSelect)
 	}
 	return "", false
 }


### PR DESCRIPTION
## Summary:

- Resource level select view keyed as `select`.
- Key published as constant.